### PR TITLE
Wrong url to projects.spring.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This project is an umbrella and the git repository is used only for
-documentation (see gh-pages branch). Home page: https://projects.spring.io/spring-cloud.
+documentation (see gh-pages branch). Home page: http://projects.spring.io/spring-cloud.
 
 The sub-projects of Spring Cloud live in a different Github
 organization: https://github.com/spring-cloud


### PR DESCRIPTION
Not sure if it is an omit - but linking to https://projects.spring.io/spring-cloud gives an `unknown domain: projects.spring.io` error. Changing it to http url works.
