### PR TITLE
Fixed Camden and Dalston quickstart snippets

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@ Release train contents:
 |spring-cloud-sleuth |                 | 1.0.11.RELEASE | 1.1.2.RELEASE          | 1.1.3.BUILD-SNAPSHOT   |
 |spring-cloud-stream |                 | 1.0.2.RELEASE | Brooklyn.SR2           | Brooklyn.BUILD-SNAPSHOT   |
 |spring-cloud-zookeeper |              | 1.0.3.RELEASE | 1.0.3.RELEASE   | 1.0.4.BUILD-SNAPSHOT   |
-|spring-boot            | 1.2.8.RELEASE| 1.3.8.RELEASE | 1.4.4.RELEASE          | 1.5.0.BUILD-SNAPSHOT          |
+|spring-boot            | 1.2.8.RELEASE| 1.3.8.RELEASE | 1.4.4.RELEASE          | 1.5.1.BUILD-SNAPSHOT          |
 |spring-cloud-task   |                |1.0.3.RELEASE   | 1.0.3.RELEASE          | 1.0.4.BUILD-SNAPSHOT   |
 
 The Brixton release train builds on Spring Boot 1.3.x, but is also

--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@ Release train contents:
 |spring-cloud-sleuth |                 | 1.0.11.RELEASE | 1.1.2.RELEASE          | 1.1.3.BUILD-SNAPSHOT   |
 |spring-cloud-stream |                 | 1.0.2.RELEASE | Brooklyn.SR2           | Brooklyn.BUILD-SNAPSHOT   |
 |spring-cloud-zookeeper |              | 1.0.3.RELEASE | 1.0.3.RELEASE   | 1.0.4.BUILD-SNAPSHOT   |
-|spring-boot            | 1.2.8.RELEASE| 1.3.8.RELEASE | 1.4.4.RELEASE          | 1.4.5.BUILD-SNAPSHOT          |
+|spring-boot            | 1.2.8.RELEASE| 1.3.8.RELEASE | 1.4.4.RELEASE          | 1.5.0.BUILD-SNAPSHOT          |
 |spring-cloud-task   |                |1.0.3.RELEASE   | 1.0.3.RELEASE          | 1.0.4.BUILD-SNAPSHOT   |
 
 The Brixton release train builds on Spring Boot 1.3.x, but is also

--- a/js/projectDocumentationWidget.js
+++ b/js/projectDocumentationWidget.js
@@ -150,8 +150,10 @@ Spring.SnippetView = Backbone.View.extend({
   },
 
   render: function () {
-
-    this.model.bootVersion = this.model.version.indexOf("Camden")!=-1 ? "1.4.0.RELEASE" : (this.model.version.indexOf("Brixton")!=-1 ? "1.3.7.RELEASE" : "1.2.8.RELEASE");
+    this.model.bootVersion = this.model.version.indexOf("Dalston")!=-1 ? "1.5.0.BUILD-SNAPSHOT" :
+                             this.model.version.indexOf("Camden")!=-1 ? "1.4.4.RELEASE" :
+                             this.model.version.indexOf("Brixton")!=-1 ? "1.3.8.RELEASE" :
+                             "1.2.8.RELEASE";
     console.log(JSON.stringify(this.model))
     var html = $(this.combinedTemplate(this.model));
     this.$el.html(html);

--- a/js/projectDocumentationWidget.js
+++ b/js/projectDocumentationWidget.js
@@ -150,7 +150,7 @@ Spring.SnippetView = Backbone.View.extend({
   },
 
   render: function () {
-    this.model.bootVersion = this.model.version.indexOf("Dalston")!=-1 ? "1.5.0.BUILD-SNAPSHOT" :
+    this.model.bootVersion = this.model.version.indexOf("Dalston")!=-1 ? "1.5.1.BUILD-SNAPSHOT" :
                              this.model.version.indexOf("Camden")!=-1 ? "1.4.4.RELEASE" :
                              this.model.version.indexOf("Brixton")!=-1 ? "1.3.8.RELEASE" :
                              "1.2.8.RELEASE";


### PR DESCRIPTION
Fixed Camden and Dalston quickstart snippets: spring boot version didn't match the actual versions in the pom.xml.
