### PR TITLE
Camden updated to Boot 1.4.5.RELEASE

### DIFF
--- a/js/projectDocumentationWidget.js
+++ b/js/projectDocumentationWidget.js
@@ -105,7 +105,7 @@ Spring.SnippetView = Backbone.View.extend({
 
   render: function () {
     this.model.bootVersion = this.model.version.indexOf("Dalston")!=-1 ? "1.5.2.RELEASE" :
-                             this.model.version.indexOf("Camden")!=-1 ? "1.4.4.RELEASE" :
+                             this.model.version.indexOf("Camden")!=-1 ? "1.4.5.RELEASE" :
                              this.model.version.indexOf("Brixton")!=-1 ? "1.3.8.RELEASE" :
                              "1.2.8.RELEASE";
     console.log(JSON.stringify(this.model))


### PR DESCRIPTION
Updated code snippet to match latest Spring Boot 1.4 for Spring Cloud Camden release train.