### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 This project is an umbrella and the git repository is used only for
-documentation (see gh-pages branch). Home page: http://projects.spring.io/spring-cloud.
+documentation (see gh-pages branch). Home page: https://projects.spring.io/spring-cloud.
 
 The sub-projects of Spring Cloud live in a different Github
 organization: https://github.com/spring-cloud. Please use the 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://projects.spring.io/spring-cloud with 1 occurrences migrated to:  
  https://projects.spring.io/spring-cloud ([https](https://projects.spring.io/spring-cloud) result 301).